### PR TITLE
Added 2 new transformers for inline require and universal replace

### DIFF
--- a/transforms/index.js
+++ b/transforms/index.js
@@ -3,12 +3,23 @@ import toNamedImport from "./require-with-props-to-named-import";
 import toExportDefault from "./module-exports-to-export-default";
 import toNamedExport from "./module-exports-to-named-export";
 import singleRequire from "./single-require";
+import toNamedAndDefaultExport from "./module-exports-to-named-and-default-export";
+import inlineRequireToVariable from "./inline-require-to-imports-with-variable";
 
 const transformScripts = (fileInfo, api, options) => {
-    return [toExportDefault, toNamedImport, singleRequire, toImportDefault, toNamedExport].reduce((input, script) => {
+    return [
+        toNamedAndDefaultExport,
+        // toExportDefault,
+        toNamedImport,
+        singleRequire,
+        toImportDefault,
+        toNamedExport,
+        inlineRequireToVariable,
+    ].reduce((input, script) => {
         return script(
             {
-                source: input
+                source: input,
+                path: fileInfo.path
             },
             api,
             options

--- a/transforms/inline-require-to-imports-with-variable.js
+++ b/transforms/inline-require-to-imports-with-variable.js
@@ -1,0 +1,53 @@
+/**
+ * Transform
+ *
+ *   foo(require('lib'))
+ *
+ * to
+ *
+ *   import lib from 'lib';
+ *   ...
+ *   foo(lib)
+ *
+ */
+
+import Logger from "./utils/logger";
+
+function toCamelCase(str) {
+    return str.toLowerCase().replace(/[^a-zA-Z0-9]+(.)/g, (_, word, idx) => idx === 0 ? word : word.toUpperCase());
+}
+function toVariableName(str) {
+    return toCamelCase(str).replace(/^\d/, '_');
+}
+
+function transformer(file, api, options) {
+    const j = api.jscodeshift;
+    const logger = new Logger(file, options);
+
+    // ------------------------------------------------------------------ SEARCH
+    const nodes = j(file.source)
+        .find(j.CallExpression, {
+            callee: {
+                name: "require"
+            }
+        });
+
+    logger.log(`${nodes.length} nodes will be transformed`);
+
+    // ----------------------------------------------------------------- REPLACE
+    const newImports = [];
+    const replaceResult = nodes
+        .replaceWith((path) => {
+            const identifier = j.identifier(toVariableName(path.node.arguments[0].value));
+            const importNode = j.importDeclaration([j.importDefaultSpecifier(identifier)], path.node.arguments[0]);
+
+            newImports.push(importNode);
+            return identifier;
+        })
+        .toSource();
+    const firstNode = j(replaceResult).find(j.Node, {}).at(1);
+
+    return firstNode.insertBefore(() => newImports).toSource();
+}
+
+export default transformer;

--- a/transforms/module-exports-to-named-and-default-export.js
+++ b/transforms/module-exports-to-named-and-default-export.js
@@ -1,0 +1,111 @@
+/**
+ * Transform
+ *
+ *   module.exports = { foo };
+ *
+ * to both
+ *
+ *   export default { foo };
+ * and
+ *   export const foo;
+ *
+ * Only on global context
+ */
+
+import Logger from "./utils/logger";
+import { isTopNode } from "./utils/filters";
+
+function transformer(file, api, options) {
+    const j = api.jscodeshift;
+    const _isTopNode = (path) => isTopNode(j, path);
+    const logger = new Logger(file, options);
+
+    // ------------------------------------------------------------------ SEARCH
+    const nodes = j(file.source)
+        .find(j.ExpressionStatement, {
+            expression: {
+                left: {
+                    object: {
+                        name: "module"
+                    },
+                    property: {
+                        name: "exports"
+                    }
+                },
+                operator: "="
+            }
+        })
+        .filter(_isTopNode);
+
+    if (nodes.length > 1) {
+        logger.error(
+            "There should not be more than one `module.exports` declaration in a file. Aborting transformation"
+        );
+        return file.source;
+    }
+
+    logger.log(`${nodes.length} nodes will be transformed`);
+
+    // ----------------------------------------------------------------- REPLACE
+    return nodes
+        .replaceWith((path) => {
+            // Если экспортируется объект со свойствами, module.exports = { ... }
+            if (Array.isArray(path.node.expression.right.properties)) {
+                const exportConstNodes = [];
+                const namedExportProperties = [];
+                const defaultExportProperties = [];
+
+                try {
+                    for (const property of path.node.expression.right.properties) {
+                        const variable = j.variableDeclaration('const', [
+                            j.variableDeclarator(
+                                j.identifier(property.key.name),
+                                property.value
+                            )
+                        ])
+
+                        if (!property.shorthand) {
+                            // export const foo = ...;
+                            exportConstNodes.push(j.exportDeclaration(false, variable));
+                        } else {
+                            // export { foo };
+                            namedExportProperties.push(j.exportSpecifier.from({ exported: property.key, local: property.key }));
+                        }
+                        // export default { foo };
+                        defaultExportProperties.push(property.key.name);
+                    }
+                } catch (e) {
+                    console.error(`${file.path}: adding of named exports has SKIPPED`);
+                    return j.exportDefaultDeclaration(path.node.expression.right);
+                }
+
+                let namedExportNode;
+
+                if (namedExportProperties.length > 0) {
+                    namedExportNode = j.exportNamedDeclaration(null, namedExportProperties);
+                }
+
+                const defaultExportNode = j.exportDefaultDeclaration(
+                    j.objectExpression(defaultExportProperties.map(propName => {
+                        const prop = j.property("init", j.identifier(propName), j.identifier(propName));
+
+                        prop.shorthand = true
+                        return prop;
+                    }))
+                );
+
+                defaultExportNode.comments = path.node.comments;
+
+                return [ ...exportConstNodes, namedExportNode, defaultExportNode ].filter(Boolean);
+            }
+
+            // Если экспортируется какая-то одна переменная
+            const defaultExportNode = j.exportDefaultDeclaration(path.node.expression.right);
+            defaultExportNode.comments = path.node.comments;
+
+            return defaultExportNode;
+        })
+        .toSource();
+}
+
+export default transformer;


### PR DESCRIPTION
* [module-exports-to-named-and-default-export.js](https://github.com/swapster/commonjs-to-es-module-codemod/pull/1/files#diff-17e4ba84ff81babd4bcd5c8f4ccce564e8ff8cfb7e01bbd57e2ffd7275b8ce21)
```js
module.exports = { foo };
// to
export const foo;
export default { foo };
// or
export { foo };
export default { foo };
```
* [inline-require-to-imports-with-variable.js](https://github.com/swapster/commonjs-to-es-module-codemod/pull/1/files#diff-9a614e4a77be8702a690f7dc49b651362e541b75702b6751b65652626970aa94)
```js
foo(require('lib'))
// to
import lib from 'lib';
/* ... */
foo(lib);
```